### PR TITLE
Update config and deps; release v0.2.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@
 
 services:
   - name: restbase
+    app_base_path: ./node_modules/restbase
     conf: 
       port: 7231
       salt: secret
@@ -15,21 +16,21 @@ services:
         paths:
           /{domain:localhost}:
             x-modules:
-              /:
-                - path: projects/example.yaml
-                  options:
-                    action:
-                      # XXX Check API URL!
-                      apiUriTemplate: http://localhost/w/api.php
-                    parsoid:
-                      # XXX Check Parsoid URL!
-                      host: http://localhost:8142
-                    table:
-                      dbname: /data/restbase_tables.sqlite3
-                      pool_idle_timeout: 20000
-                      retry_delay: 250
-                      retry_limit: 10
-                      show_sql: false
+              - path: projects/example.yaml
+                options:
+                  action:
+                    # XXX Check API URL!
+                    apiUriTemplate: '{env(MEDIAWIKI_API_URL,http://localhost/w/api.php)}'
+                  parsoid:
+                    # XXX Check Parsoid URL!
+                    host: http://localhost:8142
+                  table:
+                    backend: sqlite
+                    dbname: /data/restbase_tables.sqlite3
+                    pool_idle_timeout: 20000
+                    retry_delay: 250
+                    retry_limit: 10
+                    show_sql: false
   - name: parsoid
     entrypoint: apiServiceWorker
     conf:
@@ -40,8 +41,7 @@ services:
       mwApis:
         - domain: localhost
           prefix: localhost
-          uri: 'http://localhost/w/api.php'
-          
+          uri: '{env(MEDIAWIKI_API_URL,http://localhost/w/api.php)}'
 
 # Finally, a standard service-runner config.
 info:
@@ -49,3 +49,5 @@ info:
 
 logging:
   level: info
+
+num_workers: 1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,11 +5,4 @@ cd /src
 
 OPTS="-n 1"
 
-if [ ! -z "$MEDIAWIKI_API_URL" ];then
-    cleanedURL=$(echo $MEDIAWIKI_API_URL | sed -e 's/\//\\\//g')
-    sed -e "s/http:\\/\\/localhost\\/w\\/api.php/$cleanedURL/" \
-        < config.yaml > config.local.yaml
-    exec node server -c config.local.yaml $OPTS
-else
-    exec node server -c config.yaml $OPTS
-fi
+exec node server -c config.yaml $OPTS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediawiki-node-services",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Run several mediawiki nodejs services (RESTBase, Parsoid) in a single docker container. Useful for small / low-memory installs.",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gwicke/mediawiki-node-services.git"
+    "url": "https://github.com/wikimedia/mediawiki-node-services.git"
   },
   "keywords": [
     "mediawiki",
@@ -17,15 +17,19 @@
     "restbase",
     "docker"
   ],
-  "author": "Gabriel Wicke <gwicke@wikimedia.org>",
+  "author": "WMF Services team <services@lists.wikimedia.org>",
+  "contributors": [
+    "Gabriel Wicke <gwicke@wikimedia.org>",
+    "Marko Obrovac <mobrovac@wikimedia.org>"
+  ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/gwicke/mediawiki-node-services/issues"
+    "url": "https://github.com/wikimedia/mediawiki-node-services/issues"
   },
   "dependencies": {
     "parsoid": "git+https://github.com/gwicke/parsoid.git",
-    "restbase": "^0.9.1",
-    "service-runner": "^0.3.1",
-    "restbase-mod-table-sqlite": "^0.1.10"
+    "restbase": "^0.15.0",
+    "service-runner": "^2.1.0",
+    "restbase-mod-table-sqlite": "^0.1.18"
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,4 +4,4 @@
 
 // B/C wrapper to make the old init script work with service-runner.
 var ServiceRunner = require('service-runner');
-new ServiceRunner().run();
+new ServiceRunner().start();


### PR DESCRIPTION
This patch brings mediawiki-node-services up to date with the latest RESTBase and service-runner developments.
