### PR TITLE
Add option for using self-signed SSL certificates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,6 +69,7 @@ services:
         - domain: localhost
           prefix: localhost
           uri: '{env(MEDIAWIKI_API_URL,http://localhost/w/api.php)}'
+          strictSSL: '{env(STRICT_SSL,true)}'
 
 # Finally, a standard service-runner config.
 info:


### PR DESCRIPTION
Add option for using self-signed SSL certificates with Parsoid service.
In order to use self-signed SSL certificate set:
strictSSL=false
